### PR TITLE
Make box last line linefeed optional

### DIFF
--- a/box.go
+++ b/box.go
@@ -35,9 +35,10 @@ import (
 type BoxStyle func(*boxOptions)
 
 type boxOptions struct {
-	headlineColor  *colorful.Color
-	contentColor   *colorful.Color
-	headlineStyles []bunt.StyleOption
+	headlineColor      *colorful.Color
+	contentColor       *colorful.Color
+	headlineStyles     []bunt.StyleOption
+	noClosingEndOfLine bool
 }
 
 // HeadlineColor sets the color of the headline text
@@ -58,6 +59,13 @@ func HeadlineStyle(style bunt.StyleOption) BoxStyle {
 func ContentColor(color colorful.Color) BoxStyle {
 	return func(options *boxOptions) {
 		options.contentColor = &color
+	}
+}
+
+// NoFinalEndOfLine specifies that the rendering does not add a closing linefeed
+func NoFinalEndOfLine() BoxStyle {
+	return func(options *boxOptions) {
+		options.noClosingEndOfLine = true
 	}
 }
 
@@ -120,6 +128,11 @@ func Box(out io.Writer, headline string, content io.Reader, opts ...BoxStyle) {
 	}
 
 	if linewritten {
-		outprint("%s\n", lastline)
+		outprint(lastline)
+
+		// If not configured otherwise, end with a linefeed
+		if !options.noClosingEndOfLine {
+			outprint("\n")
+		}
 	}
 }

--- a/box_test.go
+++ b/box_test.go
@@ -123,6 +123,19 @@ DodgerBlue{│} DimGray{content}
 DodgerBlue{╵}
 `)))
 		})
+
+		It("should create a content box with no trailing line feed", func() {
+			Expect("\n" + ContentBox(
+				headline,
+				content,
+				NoFinalEndOfLine(),
+			)).To(BeEquivalentTo(Sprintf(`
+╭ headline
+│ multi
+│ line
+│ content
+╵`)))
+		})
 	})
 
 	Context("rendering content boxes with already colored content", func() {


### PR DESCRIPTION
There are scenarios where the box takes up the whole terminal height. In those
use cases, the linefeed at the last line takes away the possibility to use the
full terminal.

Make the linefeed at the last line configurable by introducing a box style
function called `NoFinalEndOfLine`. By default, a linefeed is added.