### PR TITLE
Add table option to omit last line linefeed

### DIFF
--- a/table.go
+++ b/table.go
@@ -156,7 +156,7 @@ func Table(table [][]string, tableOptions ...TableOption) (string, error) {
 		}
 
 		for y, cell := range row {
-			notLastRow := y < len(row)-1
+			notLastCol := y < len(row)-1
 			fillment := strings.Repeat(
 				options.filler,
 				maxs[y]-bunt.PlainTextLength(cell),
@@ -165,7 +165,7 @@ func Table(table [][]string, tableOptions ...TableOption) (string, error) {
 			switch options.columnAlignment[y] {
 			case Left:
 				buf.WriteString(cell)
-				if notLastRow {
+				if notLastCol {
 					buf.WriteString(fillment)
 				}
 

--- a/table_test.go
+++ b/table_test.go
@@ -152,5 +152,21 @@ uno   dos tres  cuatro cinco
 			Expect(err).Should(MatchError(&ColumnIndexIsOutOfBoundsError{4}))
 			Expect(tableString).To(BeEquivalentTo(""))
 		})
+
+		It("should be possible to create a table without a final linefeed", func() {
+			input := [][]string{
+				{"eins", "zwei", "drei"},
+				{"one", "two", "three"},
+				{"un", "deux", "trois"},
+			}
+
+			expectedResult := `eins zwei drei
+one  two  three
+un   deux trois`
+
+			tableString, err := Table(input, OmitLinefeedAtTableEnd())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tableString).To(BeEquivalentTo(expectedResult))
+		})
 	})
 })


### PR DESCRIPTION
Similar to the box renderer, there are use cases where the last line linefeed
makes it impossible to use the full height of the terminal.

Add option to omit the linefeed for the last line of the table.