### PR TITLE
Fix weird table row limit behaviour

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.12
 require (
 	github.com/gonvenience/bunt v1.1.1
 	github.com/gonvenience/wrap v1.1.0
-	github.com/lucasb-eyer/go-colorful v1.0.2
+	github.com/lucasb-eyer/go-colorful v1.0.3
 	github.com/onsi/ginkgo v1.10.3
 	github.com/onsi/gomega v1.7.1
 	github.com/pkg/errors v0.8.1
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.7
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,9 @@ github.com/gonvenience/wrap v1.1.0 h1:d8gEZrXS/zg4BC1q0U4nHpPIh5k6muKpQ1+rQFBwpY
 github.com/gonvenience/wrap v1.1.0/go.mod h1:L47Cm1sK1G8QmFAYQfkHcF/sQ1IBJUa0u4sjqiLqPdM=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/lucasb-eyer/go-colorful v1.0.2 h1:mCMFu6PgSozg9tDNMMK3g18oJBX7oYGrC09mS6CXfO4=
 github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
+github.com/lucasb-eyer/go-colorful v1.0.3 h1:QIbQXiugsb+q10B+MI+7DI1oQLdmnep86tWFlaaUAac=
+github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-ciede2000 v0.0.0-20170301095244-782e8c62fec3 h1:BXxTozrOU8zgC5dkpn3J6NTRdoP+hjok/e+ACr4Hibk=
 github.com/mattn/go-ciede2000 v0.0.0-20170301095244-782e8c62fec3/go.mod h1:x1uk6vxTiVuNt6S5R2UYgdhpj3oKojXvOXauHZ7dEnI=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
@@ -19,13 +20,9 @@ github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936 h1:kw1v0NlnN+GZcU8
 github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936/go.mod h1:r1VsdOzOPt1ZSrGZWFoNhsAedKnEd6r9Np1+5blZCWk=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
-github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3 h1:OoxbjfXVZyod1fmWYhI7SEyaD8B00ynP3T+D5GiyHOY=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
-github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -50,7 +47,6 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
+gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/table.go
+++ b/table.go
@@ -152,12 +152,8 @@ func Table(table [][]string, tableOptions ...TableOption) (string, error) {
 		rowLimit int = len(table)
 	)
 
-	if options.rowLimit >= 0 {
+	if (options.rowLimit >= 0) && (options.rowLimit < len(table)) {
 		rowLimit = options.rowLimit
-	}
-
-	if rowLimit > len(table) {
-		return "", &RowLimitExceedsTableSize{Limit: rowLimit, Rows: len(table)}
 	}
 
 	for ; idx < rowLimit; idx++ {

--- a/table_error.go
+++ b/table_error.go
@@ -54,14 +54,3 @@ type ColumnIndexIsOutOfBoundsError struct {
 func (e *ColumnIndexIsOutOfBoundsError) Error() string {
 	return fmt.Sprintf("unable to render table, the provided column index %d is out of bounds", e.ColumnIdx)
 }
-
-// RowLimitExceedsTableSize is used to describe that the specified maximum row
-// number exceeds the actual number of rows in the table
-type RowLimitExceedsTableSize struct {
-	Limit int
-	Rows  int
-}
-
-func (e *RowLimitExceedsTableSize) Error() string {
-	return fmt.Sprintf("unable to render table, the provided row limit of %d exceeds the number of rows %d", e.Limit, e.Rows)
-}

--- a/table_test.go
+++ b/table_test.go
@@ -186,16 +186,21 @@ one  two  three
 			Expect(tableString).To(BeEquivalentTo(expectedResult))
 		})
 
-		It("should fail when using an invalid row limit", func() {
+		It("should not fail when using a row limit which is greater than the table length", func() {
 			input := [][]string{
 				{"eins", "zwei", "drei"},
 				{"one", "two", "three"},
 				{"un", "deux", "trois"},
 			}
 
-			tableString, err := Table(input, LimitRows(4))
-			Expect(err).Should(MatchError(&RowLimitExceedsTableSize{4, 3}))
-			Expect(tableString).To(BeEquivalentTo(""))
+			expectedResult := `eins zwei drei
+one  two  three
+un   deux trois
+`
+
+			tableString, err := Table(input, LimitRows(25))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tableString).To(BeEquivalentTo(expectedResult))
 		})
 	})
 })


### PR DESCRIPTION
If a table row limit is specified that is greater than the actual size
of the table, an error is created. This makes sense from a programming
point of view, however it is counter intuitive when using the feature as
most developers would assume that if the row limit is greater than the
row count, only the available content is displayed.

Remove `RowLimitExceedsTableSize` error struct and code.

Change row limit condition to only set a row limit if it is in the
bounds of the table rows.

Fix test case to not test for an out of bounds error, but that the table
is printed in its entirety even though a high row limit is set.