### PR TITLE
Rename Go-YAML import from yaml to yamlv2

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -27,9 +27,10 @@ import (
 	"io"
 	"os"
 
-	. "github.com/gonvenience/neat"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	. "github.com/gonvenience/neat"
 
 	"github.com/gonvenience/bunt"
 	"github.com/gonvenience/wrap"

--- a/json_test.go
+++ b/json_test.go
@@ -21,18 +21,19 @@
 package neat_test
 
 import (
-	. "github.com/gonvenience/neat"
-	yaml "gopkg.in/yaml.v2"
+	yamlv2 "gopkg.in/yaml.v2"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	. "github.com/gonvenience/neat"
 )
 
 var _ = Describe("YAML to JSON tests", func() {
 	Context("Processing valid YAML input", func() {
 		It("should convert YAML to JSON", func() {
-			var content yaml.MapSlice
-			if err := yaml.Unmarshal([]byte(`---
+			var content yamlv2.MapSlice
+			if err := yamlv2.Unmarshal([]byte(`---
 name: foobar
 list:
 - A

--- a/neat_suite_test.go
+++ b/neat_suite_test.go
@@ -23,10 +23,10 @@ package neat_test
 import (
 	"testing"
 
-	. "github.com/gonvenience/bunt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	. "github.com/gonvenience/bunt"
 )
 
 func TestCore(t *testing.T) {

--- a/output.go
+++ b/output.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/gonvenience/bunt"
 	colorful "github.com/lucasb-eyer/go-colorful"
-	yaml "gopkg.in/yaml.v2"
+	yamlv2 "gopkg.in/yaml.v2"
 )
 
 // DefaultColorSchema is a prepared usable color schema for the neat output
@@ -108,7 +108,7 @@ func (p *OutputProcessor) determineColorByType(obj interface{}) string {
 
 func (p *OutputProcessor) isScalar(obj interface{}) bool {
 	switch obj.(type) {
-	case yaml.MapSlice, []interface{}, []yaml.MapSlice:
+	case yamlv2.MapSlice, []interface{}, []yamlv2.MapSlice:
 		return false
 
 	default:
@@ -116,7 +116,7 @@ func (p *OutputProcessor) isScalar(obj interface{}) bool {
 	}
 }
 
-func (p *OutputProcessor) simplify(list []yaml.MapSlice) []interface{} {
+func (p *OutputProcessor) simplify(list []yamlv2.MapSlice) []interface{} {
 	result := make([]interface{}, len(list))
 	for idx, value := range list {
 		result[idx] = value

--- a/output_json.go
+++ b/output_json.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 
 	"github.com/gonvenience/bunt"
-	yaml "gopkg.in/yaml.v2"
+	yamlv2 "gopkg.in/yaml.v2"
 )
 
 // ToJSONString marshals the provided object into JSON with text decorations
@@ -66,7 +66,7 @@ func (p *OutputProcessor) ToCompactJSON(obj interface{}) (string, error) {
 
 		return fmt.Sprintf("[%s]", strings.Join(result, ", ")), nil
 
-	case yaml.MapSlice:
+	case yamlv2.MapSlice:
 		result := make([]string, 0)
 		for _, i := range v {
 			value, err := p.ToCompactJSON(i)
@@ -78,7 +78,7 @@ func (p *OutputProcessor) ToCompactJSON(obj interface{}) (string, error) {
 
 		return fmt.Sprintf("{%s}", strings.Join(result, ", ")), nil
 
-	case yaml.MapItem:
+	case yamlv2.MapItem:
 		key, keyError := p.ToCompactJSON(v.Key)
 		if keyError != nil {
 			return "", keyError
@@ -103,7 +103,7 @@ func (p *OutputProcessor) ToCompactJSON(obj interface{}) (string, error) {
 
 func (p *OutputProcessor) neatJSON(prefix string, obj interface{}) (string, error) {
 	switch t := obj.(type) {
-	case yaml.MapSlice:
+	case yamlv2.MapSlice:
 		if err := p.neatJSONofYAMLMapSlice(prefix, t); err != nil {
 			return "", err
 		}
@@ -113,7 +113,7 @@ func (p *OutputProcessor) neatJSON(prefix string, obj interface{}) (string, erro
 			return "", err
 		}
 
-	case []yaml.MapSlice:
+	case []yamlv2.MapSlice:
 		if err := p.neatJSONofSlice(prefix, p.simplify(t)); err != nil {
 			return "", err
 		}
@@ -128,7 +128,7 @@ func (p *OutputProcessor) neatJSON(prefix string, obj interface{}) (string, erro
 	return p.data.String(), nil
 }
 
-func (p *OutputProcessor) neatJSONofYAMLMapSlice(prefix string, mapslice yaml.MapSlice) error {
+func (p *OutputProcessor) neatJSONofYAMLMapSlice(prefix string, mapslice yamlv2.MapSlice) error {
 	if len(mapslice) == 0 {
 		p.out.WriteString(p.colorize("{}", "emptyStructures"))
 		return nil

--- a/output_yaml.go
+++ b/output_yaml.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/gonvenience/bunt"
-	yaml "gopkg.in/yaml.v2"
+	yamlv2 "gopkg.in/yaml.v2"
 )
 
 // ToYAMLString marshals the provided object into YAML with text decorations
@@ -48,7 +48,7 @@ func (p *OutputProcessor) ToYAML(obj interface{}) (string, error) {
 
 func (p *OutputProcessor) neatYAML(prefix string, skipIndentOnFirstLine bool, obj interface{}) error {
 	switch t := obj.(type) {
-	case yaml.MapSlice:
+	case yamlv2.MapSlice:
 		if err := p.neatYAMLofMapSlice(prefix, skipIndentOnFirstLine, t); err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ func (p *OutputProcessor) neatYAML(prefix string, skipIndentOnFirstLine bool, ob
 			return err
 		}
 
-	case []yaml.MapSlice:
+	case []yamlv2.MapSlice:
 		if err := p.neatYAMLofSlice(prefix, skipIndentOnFirstLine, p.simplify(t)); err != nil {
 			return err
 		}
@@ -72,7 +72,7 @@ func (p *OutputProcessor) neatYAML(prefix string, skipIndentOnFirstLine bool, ob
 	return nil
 }
 
-func (p *OutputProcessor) neatYAMLofMapSlice(prefix string, skipIndentOnFirstLine bool, mapslice yaml.MapSlice) error {
+func (p *OutputProcessor) neatYAMLofMapSlice(prefix string, skipIndentOnFirstLine bool, mapslice yamlv2.MapSlice) error {
 	for i, mapitem := range mapslice {
 		if !skipIndentOnFirstLine || i > 0 {
 			p.out.WriteString(prefix)
@@ -86,15 +86,15 @@ func (p *OutputProcessor) neatYAMLofMapSlice(prefix string, skipIndentOnFirstLin
 		p.out.WriteString(p.colorize(keyString, "keyColor"))
 
 		switch mapitem.Value.(type) {
-		case yaml.MapSlice:
-			if len(mapitem.Value.(yaml.MapSlice)) == 0 {
+		case yamlv2.MapSlice:
+			if len(mapitem.Value.(yamlv2.MapSlice)) == 0 {
 				p.out.WriteString(" ")
 				p.out.WriteString(p.colorize("{}", "emptyStructures"))
 				p.out.WriteString("\n")
 
 			} else {
 				p.out.WriteString("\n")
-				if err := p.neatYAMLofMapSlice(prefix+p.prefixAdd(), false, mapitem.Value.(yaml.MapSlice)); err != nil {
+				if err := p.neatYAMLofMapSlice(prefix+p.prefixAdd(), false, mapitem.Value.(yamlv2.MapSlice)); err != nil {
 					return err
 				}
 			}
@@ -144,7 +144,7 @@ func (p *OutputProcessor) neatYAMLofScalar(prefix string, skipIndentOnFirstLine 
 	}
 
 	// Any other value: Run through Go YAML marshaller and colorize afterwards
-	data, err := yaml.Marshal(obj)
+	data, err := yamlv2.Marshal(obj)
 	if err != nil {
 		return err
 	}

--- a/output_yaml_test.go
+++ b/output_yaml_test.go
@@ -25,14 +25,15 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/gonvenience/neat"
-	yaml "gopkg.in/yaml.v2"
+
+	yamlv2 "gopkg.in/yaml.v2"
 )
 
 var _ = Describe("JSON to YAML tests", func() {
 	Context("Processing valid JSON input", func() {
 		It("should convert JSON to YAML", func() {
-			var content yaml.MapSlice
-			if err := yaml.Unmarshal([]byte(`{ "name": "foobar", "list": [A, B, C] }`), &content); err != nil {
+			var content yamlv2.MapSlice
+			if err := yamlv2.Unmarshal([]byte(`{ "name": "foobar", "list": [A, B, C] }`), &content); err != nil {
 				Fail(err.Error())
 			}
 
@@ -48,8 +49,8 @@ list:
 		})
 
 		It("should preserve the order inside the structure", func() {
-			var content yaml.MapSlice
-			err := yaml.Unmarshal([]byte(`{ "list": [C, B, A], "name": "foobar" }`), &content)
+			var content yamlv2.MapSlice
+			err := yamlv2.Unmarshal([]byte(`{ "list": [C, B, A], "name": "foobar" }`), &content)
 			if err != nil {
 				Fail(err.Error())
 			}


### PR DESCRIPTION
In order to help with the later migration to Go-YAML version 3, rename
all import of the YAML library to `yamlv2`.