### PR TITLE
Fix staticcheck/lint findings

### DIFF
--- a/table.go
+++ b/table.go
@@ -148,8 +148,8 @@ func Table(table [][]string, tableOptions ...TableOption) (string, error) {
 
 	var (
 		buf      bytes.Buffer
-		idx      int = 0
-		rowLimit int = len(table)
+		idx      = 0
+		rowLimit = len(table)
 	)
 
 	if (options.rowLimit >= 0) && (options.rowLimit < len(table)) {


### PR DESCRIPTION
There were two minor staticcheck/lint findings:
```
table.go:151:18: should drop = 0 from declaration of var idx; it is the zero value
table.go:152:12: should omit type int from declaration of var rowLimit; it will be inferred from the right-hand side
```

Remove redundant type as suggested by `golint`.