### PR TITLE
Add support for YAML anchors

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gonvenience/bunt v1.1.1 h1:isYxOpDqbRMOSRhZtoux1tYvhhQ/AIbVDFrs24l6t0M=
 github.com/gonvenience/bunt v1.1.1/go.mod h1:lsyhkmNpSAzhVx059BD0fQy5F29rWcS6AHb7UWNlT/s=
@@ -22,13 +20,9 @@ github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936 h1:kw1v0NlnN+GZcU8
 github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936/go.mod h1:r1VsdOzOPt1ZSrGZWFoNhsAedKnEd6r9Np1+5blZCWk=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.10.3 h1:OoxbjfXVZyod1fmWYhI7SEyaD8B00ynP3T+D5GiyHOY=
-github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
-github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.8.1 h1:C5Dqfs/LeauYDX0jJXIe2SWmwCbGzx9yF8C8xy3Lh34=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -39,7 +33,6 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -50,7 +43,6 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/output.go
+++ b/output.go
@@ -45,6 +45,7 @@ var DefaultColorSchema = map[string]colorful.Color{
 	"binaryColor":        bunt.Aqua,
 	"emptyStructures":    bunt.PaleGoldenrod,
 	"commentColor":       bunt.DimGray,
+	"anchorColor":        bunt.CornflowerBlue,
 }
 
 // OutputProcessor provides the functionality to output neat YAML strings using

--- a/output_yaml.go
+++ b/output_yaml.go
@@ -217,9 +217,9 @@ func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bo
 			switch value.Kind {
 			case yamlv3.MappingNode:
 				if len(value.Content) == 0 {
-					fmt.Fprint(p.out, " ", p.colorize("{}", "emptyStructures"), "\n")
+					fmt.Fprint(p.out, p.createAnchorDefinition(value), " ", p.colorize("{}", "emptyStructures"), "\n")
 				} else {
-					fmt.Fprint(p.out, "\n")
+					fmt.Fprint(p.out, p.createAnchorDefinition(value), "\n")
 					if err := p.neatYAMLofNode(prefix+p.prefixAdd(), false, value); err != nil {
 						return err
 					}
@@ -227,22 +227,22 @@ func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bo
 
 			case yamlv3.SequenceNode:
 				if len(value.Content) == 0 {
-					fmt.Fprint(p.out, " ", p.colorize("[]", "emptyStructures"), "\n")
+					fmt.Fprint(p.out, p.createAnchorDefinition(value), " ", p.colorize("[]", "emptyStructures"), "\n")
 				} else {
-					fmt.Fprint(p.out, "\n")
+					fmt.Fprint(p.out, p.createAnchorDefinition(value), "\n")
 					if err := p.neatYAMLofNode(prefix, false, value); err != nil {
 						return err
 					}
 				}
 
 			case yamlv3.ScalarNode:
-				fmt.Fprint(p.out, " ")
+				fmt.Fprint(p.out, p.createAnchorDefinition(value), " ")
 				if err := p.neatYAMLofNode(prefix+p.prefixAdd(), false, value); err != nil {
 					return err
 				}
 
-			default:
-				return fmt.Errorf("kind %v in mapping context as value is not implemented yet", value.Kind)
+			case yamlv3.AliasNode:
+				fmt.Fprintf(p.out, " %s\n", p.colorize("*"+value.Value, "anchorColor"))
 			}
 
 			if len(key.FootComment) > 0 {
@@ -309,4 +309,12 @@ func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bo
 	}
 
 	return nil
+}
+
+func (p *OutputProcessor) createAnchorDefinition(node *yamlv3.Node) string {
+	if len(node.Anchor) != 0 {
+		return fmt.Sprint(" ", p.colorize("&"+node.Anchor, "anchorColor"))
+	}
+
+	return ""
 }

--- a/output_yaml_test.go
+++ b/output_yaml_test.go
@@ -165,27 +165,24 @@ empty-scalar: null
 	Context("create YAML output (go-yaml v3)", func() {
 		It("should create YAML output based on YAML node structure", func() {
 			example := []byte(`---
-# before document
+# start of document
 
 # before map
 map: # at map definition
   key: value # value
-# after map
 
-# before scalar
+# before scalars
 scalars: # at scalar definition
   boolean: true # true
   number: 42 # 42
   float: 47.11
   string: foobar
   data: !!binary Zm9vYmFyCg==
-# after scaler
 
 # before list
 list: # at list definition
 - one # one
 - two # two
-# after list
 
 # before multiline
 multiline: |
@@ -193,52 +190,76 @@ multiline: |
   a multi
   line te
   xt.
-# after multiline
 
 # before zeros
 zeros:
   map: {}
   list: []
   scalar: nil
-# after zeros
 
-# after document
+# before anchors
+anchors:
+  scalar: &scalaranchor 42
+  same-scalar: *scalaranchor
+  list: &listanchor
+  - one
+  - two
+  same-list: *listanchor
+  empty-list: &emptylist []
+  same-empty-list: *emptylist
+  map: &mapanchor
+    key: value
+  same-map: *mapanchor
+  empty-map: &emptymap {}
+  same-empty-map: *emptymap
+
+# end of document
 `)
 
 			expected := `---
-# before document
+# start of document
 
 # before map
 map:
   key: value # value
-# after map
-# before scalar
+# before scalars
 scalars:
   boolean: true # true
   number: 42 # 42
   float: 47.11
   string: foobar
   data: Zm9vYmFyCg==
-# after scaler
 # before list
 list:
 - one # one
 - two # two
-# after list
 # before multiline
 multiline: |
   This is
   a multi
   line te
   xt.
-# after multiline
 # before zeros
 zeros:
   map: {}
   list: []
   scalar: nil
-# after zeros
-# after document
+# before anchors
+anchors:
+  scalar: &scalaranchor 42
+  same-scalar: *scalaranchor
+  list: &listanchor
+  - one
+  - two
+  same-list: *listanchor
+  empty-list: &emptylist []
+  same-empty-list: *emptylist
+  map: &mapanchor
+    key: value
+  same-map: *mapanchor
+  empty-map: &emptymap {}
+  same-empty-map: *emptymap
+# end of document
 `
 
 			var node yamlv3.Node


### PR DESCRIPTION
The YAML anchors and aliases were never shown in the YAML output.

Add support for YAML anchors for Go YAML v3 based documents.