### PR TITLE
Fix prefix issue in named entry lists

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/output_yaml.go
+++ b/output_yaml.go
@@ -194,7 +194,7 @@ func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bo
 	case yamlv3.SequenceNode:
 		for _, entry := range node.Content {
 			fmt.Fprint(p.out, prefix, p.colorize("-", "dashColor"), " ")
-			if err := p.neatYAMLofNode(prefix+p.prefixAdd(), skipIndentOnFirstLine, entry); err != nil {
+			if err := p.neatYAMLofNode(prefix+p.prefixAdd(), true, entry); err != nil {
 				return err
 			}
 		}

--- a/output_yaml_test.go
+++ b/output_yaml_test.go
@@ -269,5 +269,60 @@ anchors:
 			Expect(err).ToNot(HaveOccurred())
 			Expect(output).To(BeEquivalentTo(expected))
 		})
+
+		It("should create YAML output of so called named entry lists", func() {
+			example := []byte(`---
+yaml:
+  named-entry-list-using-name:
+  - name: A
+  - name: B
+  - name: C
+  - name: X
+  - name: Z
+
+  named-entry-list-using-key:
+  - key: A
+  - key: B
+  - key: C
+  - key: X
+  - key: Z
+
+  named-entry-list-using-id:
+  - id: A
+  - id: B
+  - id: C
+  - id: X
+  - id: Z
+`)
+
+			expected := `---
+yaml:
+  named-entry-list-using-name:
+  - name: A
+  - name: B
+  - name: C
+  - name: X
+  - name: Z
+  named-entry-list-using-key:
+  - key: A
+  - key: B
+  - key: C
+  - key: X
+  - key: Z
+  named-entry-list-using-id:
+  - id: A
+  - id: B
+  - id: C
+  - id: X
+  - id: Z
+`
+
+			var node yamlv3.Node
+			Expect(yamlv3.Unmarshal(example, &node)).ToNot(HaveOccurred())
+
+			output, err := ToYAMLString(node)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output).To(BeEquivalentTo(expected))
+		})
 	})
 })


### PR DESCRIPTION
When trying to render named entry lists, there was a bug that put the
line prefix in a list also into the first line and therefore created a
wrong output for those lines.

Fix bug by explicitly specifying to skip the prefix at the first line.