### PR TITLE
Add JSON output support for Go YAML v3 Nodes

### DIFF
--- a/output_yaml.go
+++ b/output_yaml.go
@@ -305,7 +305,9 @@ func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bo
 		}
 
 	case yamlv3.AliasNode:
-		return fmt.Errorf("kind AliasNode is not implemented yet")
+		if err := p.neatYAMLofNode(prefix, skipIndentOnFirstLine, node.Alias); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Add Go YAML v3 Node type specific code in `ToCompactJSON` to enable the
output processor to create valid JSON from this type.

Fix missing AliasNode implementation in YAML output.