### PR TITLE
Fix indent issue in JSON marshalling

### DIFF
--- a/output_json.go
+++ b/output_json.go
@@ -219,7 +219,7 @@ func (p *OutputProcessor) neatJSONofNode(prefix string, node *yamlv3.Node) error
 			entry := followAlias(node.Content[i])
 
 			if p.isScalar(entry) {
-				p.neatJSON("", entry)
+				p.neatJSON(prefix+p.prefixAdd(), entry)
 
 			} else {
 				fmt.Fprint(p.out, prefix, p.prefixAdd())


### PR DESCRIPTION
The list entries did not use the correct indention.

Add prefix to scalar marshalling of list entries.