### PR TITLE
Fix indention problem with lists in lists

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.8.1 h1:C5Dqfs/LeauYDX0jJXIe2SWmwCbGzx9yF8C8xy3Lh34=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.0 h1:J8lpUdobwIeCI7OiSxHqEwJUKvJwicL5+3v1oe2Yb4k=
 github.com/pkg/errors v0.9.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/output_yaml.go
+++ b/output_yaml.go
@@ -192,8 +192,17 @@ func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bo
 		}
 
 	case yamlv3.SequenceNode:
-		for _, entry := range node.Content {
-			fmt.Fprint(p.out, prefix, p.colorize("-", "dashColor"), " ")
+		for i, entry := range node.Content {
+			if i == 0 {
+				if !skipIndentOnFirstLine {
+					fmt.Fprint(p.out, prefix)
+				}
+			} else {
+				fmt.Fprint(p.out, prefix)
+			}
+
+			fmt.Fprint(p.out, p.colorize("-", "dashColor"), " ")
+
 			if err := p.neatYAMLofNode(prefix+p.prefixAdd(), true, entry); err != nil {
 				return err
 			}


### PR DESCRIPTION
In `dyff`, an issue was reported that showed the wrong usage of the
indention prefix in lists in lists:
```
cluster-1
  - one list entry removed:     + two list entries added:
    - │ - x1                      - │ - x1
    │ - x5                        │ - x5
                                  │ - x10
                                  - x999
```

The correct style would be like this:
```
cluster-1
  - one list entry removed:     + two list entries added:
    - - x1                        - - x1
    │ - x5                        │ - x5
                                  │ - x10
                                  - x999
```

Add two additional checks in the sequence node code to correctly use the
indention prefix only in list entries other than the first one. An
exception of that rule is in case `skipIndentOnFirstLine` is `false`.