### PR TITLE
Add line wrap logic to box code

### DIFF
--- a/box.go
+++ b/box.go
@@ -85,9 +85,6 @@ func Box(out io.Writer, headline string, content io.Reader, opts ...BoxStyle) {
 		prefix      = "│"
 		lastline    = "╵"
 		linewritten = false
-		outprint    = func(format string, a ...interface{}) {
-			out.Write([]byte(fmt.Sprintf(format, a...)))
-		}
 	)
 
 	// Process all provided box style options
@@ -120,19 +117,19 @@ func Box(out io.Writer, headline string, content io.Reader, opts ...BoxStyle) {
 
 		if !linewritten {
 			// Write the headline string including the corner item
-			outprint("%s %s\n", beginning, headline)
+			fmt.Fprintf(out, "%s %s\n", beginning, headline)
 		}
 
-		outprint("%s %s\n", prefix, text)
+		fmt.Fprintf(out, "%s %s\n", prefix, text)
 		linewritten = true
 	}
 
 	if linewritten {
-		outprint(lastline)
+		fmt.Fprint(out, lastline)
 
 		// If not configured otherwise, end with a linefeed
 		if !options.noClosingEndOfLine {
-			outprint("\n")
+			fmt.Fprintln(out)
 		}
 	}
 }

--- a/box_test.go
+++ b/box_test.go
@@ -29,6 +29,7 @@ import (
 
 	. "github.com/gonvenience/bunt"
 	. "github.com/gonvenience/neat"
+	. "github.com/gonvenience/term"
 )
 
 var _ = Describe("content box", func() {
@@ -217,6 +218,54 @@ DimGray{╵}
 			Box(&buf, "headline", r)
 
 			Expect(len(buf.String())).To(BeIdenticalTo(0))
+		})
+	})
+
+	Context("using line wrap", func() {
+		var tmp int
+
+		BeforeEach(func() {
+			tmp = FixedTerminalWidth
+			FixedTerminalWidth = 80
+		})
+
+		AfterEach(func() {
+			FixedTerminalWidth = tmp
+		})
+
+		It("should wrap lines that are too long", func() {
+			Expect("\n" + ContentBox(
+				"headline",
+				"content with a very long first line, that is most likely an error message with a lot of context or similar",
+			)).To(BeEquivalentTo(Sprintf(`
+╭ headline
+│ content with a very long first line, that is most likely an error message
+│ with a lot of context or similar
+╵
+`)))
+		})
+
+		It("should not wrap long lines if wrapping is disabled", func() {
+			Expect("\n" + ContentBox(
+				"headline",
+				"content with a very long first line, that is most likely an error message with a lot of context or similar",
+				NoLineWrap(),
+			)).To(BeEquivalentTo(Sprintf(`
+╭ headline
+│ content with a very long first line, that is most likely an error message with a lot of context or similar
+╵
+`)))
+		})
+
+		It("should not fail with empty lines", func() {
+			Expect("\n" + ContentBox(
+				"headline",
+				" ",
+			)).To(BeEquivalentTo(Sprintf(`
+╭ headline
+│  
+╵
+`)))
 		})
 	})
 })

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/gonvenience/bunt v1.1.1
+	github.com/gonvenience/term v1.0.0
 	github.com/gonvenience/wrap v1.1.0
 	github.com/lucasb-eyer/go-colorful v1.0.3
 	github.com/onsi/ginkgo v1.12.0


### PR DESCRIPTION
It can happen that the text to be displayed in the content box overflows
the terminal width and therefore is difficult to read.

Add line wrap logic to box code, which is enabled by default.

Add option to disable line wrap.