### PR TITLE
fix string formatting when format contains a percent sign but no args

### DIFF
--- a/output.go
+++ b/output.go
@@ -93,7 +93,10 @@ func (p *OutputProcessor) colorize(text string, colorName string) string {
 }
 
 func (p *OutputProcessor) colorizef(colorName string, format string, a ...interface{}) string {
-	var text = fmt.Sprintf(format, a...)
+	var text = format
+	if len(a) > 0 {
+		text = fmt.Sprintf(format, a...)
+	}
 
 	if p.colorSchema != nil {
 		if value, ok := (*p.colorSchema)[colorName]; ok {


### PR DESCRIPTION
This patch fixes the case where the format string should be treated as a literal.

I was using `dyff` and saw this in my output:

```
rollingUpdate:
  maxSurge: 25%!(NOVERB)
  maxUnavailable: 25%!(NOVERB)
```

With this patch, I correctly see:

```
rollingUpdate:
  maxSurge: 25%
  maxUnavailable: 25%
```