### PR TITLE
Refactor `colorize`/`colorizef` functions

### DIFF
--- a/box.go
+++ b/box.go
@@ -27,7 +27,7 @@ import (
 	"io"
 	"strings"
 
-	colorful "github.com/lucasb-eyer/go-colorful"
+	"github.com/lucasb-eyer/go-colorful"
 
 	"github.com/gonvenience/bunt"
 	"github.com/gonvenience/term"

--- a/errors_test.go
+++ b/errors_test.go
@@ -48,7 +48,7 @@ var _ = Describe("error rendering", func() {
 	Context("rendering errors", func() {
 		It("should render a context error using a box", func() {
 			cause := fmt.Errorf("failed to load X and Y")
-			err := fmt.Errorf("unable to start Z: %w",cause)
+			err := fmt.Errorf("unable to start Z: %w", cause)
 
 			Expect(SprintError(err)).To(
 				BeEquivalentTo(ContentBox(

--- a/output.go
+++ b/output.go
@@ -26,29 +26,66 @@ import (
 	"fmt"
 	"strings"
 
-	colorful "github.com/lucasb-eyer/go-colorful"
 	yamlv2 "gopkg.in/yaml.v2"
 	yamlv3 "gopkg.in/yaml.v3"
 
+	"github.com/lucasb-eyer/go-colorful"
+
 	"github.com/gonvenience/bunt"
+)
+
+// frequently used output constants
+const (
+	colorAnchor        = "anchorColor"
+	colorBinary        = "binaryColor"
+	colorBool          = "boolColor"
+	colorComment       = "commentColor"
+	colorDash          = "dashColor"
+	colorFloat         = "floatColor"
+	colorIndentLine    = "indentLineColor"
+	colorInt           = "intColor"
+	colorKey           = "keyColor"
+	colorMultiLineText = "multiLineTextColor"
+	colorNull          = "nullColor"
+	colorScalarDefault = "scalarDefaultColor"
+)
+
+const (
+	documentStart   = "documentStart"
+	emptyStructures = "emptyStructures"
+)
+
+const (
+	emptyList   = "[]"
+	emptyObject = "{}"
+)
+
+const (
+	nodeTagBinary = "!!binary"
+	nodeTagBool   = "!!bool"
+	nodeTagFloat  = "!!float"
+	nodeTagInt    = "!!int"
+	nodeTagNull   = "!!null"
+	nodeTagString = "!!str"
+	nodeTagTime   = "!!timestamp"
 )
 
 // DefaultColorSchema is a prepared usable color schema for the neat output
 // processor which is loosly based upon the colors used by Atom
 var DefaultColorSchema = map[string]colorful.Color{
-	"documentStart":      bunt.LightSlateGray,
-	"keyColor":           bunt.IndianRed,
-	"indentLineColor":    {R: 0.14, G: 0.14, B: 0.14},
-	"scalarDefaultColor": bunt.PaleGreen,
-	"boolColor":          bunt.Moccasin,
-	"floatColor":         bunt.Orange,
-	"intColor":           bunt.MediumPurple,
-	"multiLineTextColor": bunt.Aquamarine,
-	"nullColor":          bunt.DarkOrange,
-	"binaryColor":        bunt.Aqua,
-	"emptyStructures":    bunt.PaleGoldenrod,
-	"commentColor":       bunt.DimGray,
-	"anchorColor":        bunt.CornflowerBlue,
+	documentStart:      bunt.LightSlateGray,
+	colorKey:           bunt.IndianRed,
+	colorIndentLine:    {R: 0.14, G: 0.14, B: 0.14},
+	colorScalarDefault: bunt.PaleGreen,
+	colorBool:          bunt.Moccasin,
+	colorFloat:         bunt.Orange,
+	colorInt:           bunt.MediumPurple,
+	colorMultiLineText: bunt.Aquamarine,
+	colorNull:          bunt.DarkOrange,
+	colorBinary:        bunt.Aqua,
+	emptyStructures:    bunt.PaleGoldenrod,
+	colorComment:       bunt.DimGray,
+	colorAnchor:        bunt.CornflowerBlue,
 }
 
 // OutputProcessor provides the functionality to output neat YAML strings using
@@ -81,8 +118,8 @@ func NewOutputProcessor(useIndentLines bool, boldKeys bool, colorSchema *map[str
 	}
 }
 
-// TODO Change signature to swap into the right order, color first, text second
-func (p *OutputProcessor) colorize(text string, colorName string) string {
+// colorize returns the given string with the color applied via bunt.
+func (p *OutputProcessor) colorize(colorName string, text string) string {
 	if p.colorSchema != nil {
 		if value, ok := (*p.colorSchema)[colorName]; ok {
 			return bunt.Style(text, bunt.Foreground(value))
@@ -92,50 +129,54 @@ func (p *OutputProcessor) colorize(text string, colorName string) string {
 	return text
 }
 
+// colorizef formats a string using the provided color name and format string (created via fmt.Sprintf)
+// and returns the formatted string with the color applied via bunt.
+//
+// If additional arguments are not provided, the function skips the fmt.Sprintf call.
 func (p *OutputProcessor) colorizef(colorName string, format string, a ...interface{}) string {
 	if len(a) > 0 {
-		return p.colorize(fmt.Sprintf(format, a...), colorName)
+		return p.colorize(colorName, fmt.Sprintf(format, a...))
 	}
 
-	return p.colorize(format, colorName)
+	return p.colorize(colorName, format)
 }
 
 func (p *OutputProcessor) determineColorByType(obj interface{}) string {
-	color := "scalarDefaultColor"
+	color := colorScalarDefault
 
 	switch t := obj.(type) {
 	case *yamlv3.Node:
 		switch t.Tag {
-		case "!!str":
+		case nodeTagString:
 			if len(strings.Split(strings.TrimSpace(t.Value), "\n")) > 1 {
-				color = "multiLineTextColor"
+				color = colorMultiLineText
 			}
 
-		case "!!int":
-			color = "intColor"
+		case nodeTagInt:
+			color = colorInt
 
-		case "!!float":
-			color = "floatColor"
+		case nodeTagFloat:
+			color = colorFloat
 
-		case "!!bool":
-			color = "boolColor"
+		case nodeTagBool:
+			color = colorBool
 
-		case "!!null":
-			color = "nullColor"
+		case nodeTagNull:
+			color = colorNull
 		}
 
 	case bool:
-		color = "boolColor"
+		color = colorBool
 
 	case float32, float64:
-		color = "floatColor"
+		color = colorFloat
 
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, uintptr:
-		color = "intColor"
+		color = colorInt
 
 	case string:
 		if len(strings.Split(strings.TrimSpace(t), "\n")) > 1 {
-			color = "multiLineTextColor"
+			color = colorMultiLineText
 		}
 	}
 
@@ -143,9 +184,9 @@ func (p *OutputProcessor) determineColorByType(obj interface{}) string {
 }
 
 func (p *OutputProcessor) isScalar(obj interface{}) bool {
-	switch tobj := obj.(type) {
+	switch tObj := obj.(type) {
 	case *yamlv3.Node:
-		return tobj.Kind == yamlv3.ScalarNode
+		return tObj.Kind == yamlv3.ScalarNode
 
 	case yamlv2.MapSlice, []interface{}, []yamlv2.MapSlice:
 		return false
@@ -166,10 +207,10 @@ func (p *OutputProcessor) simplify(list []yamlv2.MapSlice) []interface{} {
 
 func (p *OutputProcessor) prefixAdd() string {
 	if p.useIndentLines {
-		return p.colorize("│ ", "indentLineColor")
+		return p.colorize(colorIndentLine, "│ ")
 	}
 
-	return p.colorize("  ", "indentLineColor")
+	return p.colorize(colorIndentLine, "  ")
 }
 
 func followAlias(node *yamlv3.Node) *yamlv3.Node {

--- a/output_json.go
+++ b/output_json.go
@@ -215,7 +215,7 @@ func (p *OutputProcessor) neatJSONofNode(prefix string, node *yamlv3.Node) error
 
 	case yamlv3.MappingNode:
 		if len(node.Content) == 0 {
-			fmt.Fprint(p.out, p.colorize("{}", "emptyStructures"))
+			fmt.Fprint(p.out, p.colorize(emptyStructures, emptyObject))
 			return nil
 		}
 
@@ -225,7 +225,7 @@ func (p *OutputProcessor) neatJSONofNode(prefix string, node *yamlv3.Node) error
 
 			fmt.Fprint(p.out,
 				optionalIndentPrefix(),
-				p.colorize(`"`+k.Value+`"`, "keyColor"), ": ",
+				p.colorizef(colorKey, "%q", k.Value), ": ",
 			)
 
 			if p.isScalar(v) {
@@ -249,7 +249,7 @@ func (p *OutputProcessor) neatJSONofNode(prefix string, node *yamlv3.Node) error
 
 	case yamlv3.SequenceNode:
 		if len(node.Content) == 0 {
-			fmt.Fprint(p.out, p.colorize("[]", "emptyStructures"))
+			fmt.Fprint(p.out, p.colorize(emptyStructures, emptyList))
 			return nil
 		}
 
@@ -291,8 +291,8 @@ func (p *OutputProcessor) neatJSONofNode(prefix string, node *yamlv3.Node) error
 		fmt.Fprint(p.out,
 			prefix,
 			p.colorize(
-				string(bytes),
 				p.determineColorByType(node),
+				string(bytes),
 			))
 	}
 
@@ -301,7 +301,7 @@ func (p *OutputProcessor) neatJSONofNode(prefix string, node *yamlv3.Node) error
 
 func (p *OutputProcessor) neatJSONofYAMLMapSlice(prefix string, mapslice yamlv2.MapSlice) error {
 	if len(mapslice) == 0 {
-		_, _ = p.out.WriteString(p.colorize("{}", "emptyStructures"))
+		_, _ = p.out.WriteString(p.colorize(emptyStructures, emptyObject))
 		return nil
 	}
 
@@ -312,7 +312,7 @@ func (p *OutputProcessor) neatJSONofYAMLMapSlice(prefix string, mapslice yamlv2.
 		keyString := fmt.Sprintf("\"%v\": ", mapitem.Key)
 
 		_, _ = p.out.WriteString(prefix + p.prefixAdd())
-		_, _ = p.out.WriteString(p.colorize(keyString, "keyColor"))
+		_, _ = p.out.WriteString(p.colorize(colorKey, keyString))
 
 		if p.isScalar(mapitem.Value) {
 			if err := p.neatJSONofScalar("", mapitem.Value); err != nil {
@@ -340,7 +340,7 @@ func (p *OutputProcessor) neatJSONofYAMLMapSlice(prefix string, mapslice yamlv2.
 
 func (p *OutputProcessor) neatJSONofSlice(prefix string, list []interface{}) error {
 	if len(list) == 0 {
-		_, _ = p.out.WriteString(p.colorize("[]", "emptyStructures"))
+		_, _ = p.out.WriteString(p.colorize(emptyStructures, emptyList))
 		return nil
 	}
 
@@ -375,7 +375,7 @@ func (p *OutputProcessor) neatJSONofSlice(prefix string, list []interface{}) err
 
 func (p *OutputProcessor) neatJSONofScalar(prefix string, obj interface{}) error {
 	if obj == nil {
-		_, _ = p.out.WriteString(p.colorize("null", "nullColor"))
+		_, _ = p.out.WriteString(p.colorize(colorNull, "null"))
 		return nil
 	}
 
@@ -389,10 +389,10 @@ func (p *OutputProcessor) neatJSONofScalar(prefix string, obj interface{}) error
 	_, _ = p.out.WriteString(prefix)
 	parts := strings.Split(string(data), "\\n")
 	for idx, part := range parts {
-		_, _ = p.out.WriteString(p.colorize(part, color))
+		_, _ = p.out.WriteString(p.colorize(color, part))
 
 		if idx < len(parts)-1 {
-			_, _ = p.out.WriteString(p.colorize("\\n", "emptyStructures"))
+			_, _ = p.out.WriteString(p.colorize(emptyStructures, "\\n"))
 		}
 	}
 
@@ -405,22 +405,22 @@ func cast(node yamlv3.Node) (interface{}, error) {
 	}
 
 	switch node.Tag {
-	case "!!str":
+	case nodeTagString:
 		return node.Value, nil
 
-	case "!!timestamp":
+	case nodeTagTime:
 		return parseTime(node.Value)
 
-	case "!!int":
+	case nodeTagInt:
 		return strconv.Atoi(node.Value)
 
-	case "!!float":
+	case nodeTagFloat:
 		return strconv.ParseFloat(node.Value, 64)
 
-	case "!!bool":
+	case nodeTagBool:
 		return strconv.ParseBool(node.Value)
 
-	case "!!null":
+	case nodeTagNull:
 		return nil, nil
 
 	default:
@@ -429,17 +429,7 @@ func cast(node yamlv3.Node) (interface{}, error) {
 }
 
 func parseTime(value string) (time.Time, error) {
-	// YAML Spec regarding timestamp: https://yaml.org/type/timestamp.html
-	var layouts = [...]string{
-		time.RFC3339,
-		"2006-01-02T15:04:05.999999999Z",
-		"2006-01-02t15:04:05.999999999-07:00",
-		"2006-01-02 15:04:05.999999999 07:00",
-		"2006-01-02 15:04:05.999999999",
-		"2006-01-02",
-	}
-
-	for _, layout := range layouts {
+	for _, layout := range yamlTimeLayouts {
 		if result, err := time.Parse(layout, value); err == nil {
 			return result, nil
 		}

--- a/output_yaml.go
+++ b/output_yaml.go
@@ -24,11 +24,26 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	yamlv2 "gopkg.in/yaml.v2"
 	yamlv3 "gopkg.in/yaml.v3"
 
 	"github.com/gonvenience/bunt"
+)
+
+var (
+	yamlReservedKeywords = []string{"true", "false", "null"}
+
+	// YAML Spec regarding timestamp: https://yaml.org/type/timestamp.html
+	yamlTimeLayouts = [...]string{
+		time.RFC3339,
+		"2006-01-02T15:04:05.999999999Z",
+		"2006-01-02t15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999999 07:00",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02",
+	}
 )
 
 // ToYAMLString marshals the provided object into YAML with text decorations
@@ -39,7 +54,7 @@ func ToYAMLString(obj interface{}) (string, error) {
 }
 
 // ToYAML processes the provided input object and tries to neatly output it as
-// human readable YAML honoring the preferences provided to the output processor
+// human-readable YAML honoring the preferences provided to the output processor
 func (p *OutputProcessor) ToYAML(obj interface{}) (string, error) {
 	if err := p.neatYAML("", false, obj); err != nil {
 		return "", err
@@ -88,13 +103,13 @@ func (p *OutputProcessor) neatYAMLofMapSlice(prefix string, skipIndentOnFirstLin
 			keyString = bunt.Style(keyString, bunt.Bold())
 		}
 
-		_, _ = p.out.WriteString(p.colorize(keyString, "keyColor"))
+		_, _ = p.out.WriteString(p.colorize(colorKey, keyString))
 
 		switch mapitem.Value.(type) {
 		case yamlv2.MapSlice:
 			if len(mapitem.Value.(yamlv2.MapSlice)) == 0 {
 				_, _ = p.out.WriteString(" ")
-				_, _ = p.out.WriteString(p.colorize("{}", "emptyStructures"))
+				_, _ = p.out.WriteString(p.colorize(emptyStructures, emptyObject))
 				_, _ = p.out.WriteString("\n")
 
 			} else {
@@ -107,7 +122,7 @@ func (p *OutputProcessor) neatYAMLofMapSlice(prefix string, skipIndentOnFirstLin
 		case []interface{}:
 			if len(mapitem.Value.([]interface{})) == 0 {
 				_, _ = p.out.WriteString(" ")
-				_, _ = p.out.WriteString(p.colorize("[]", "emptyStructures"))
+				_, _ = p.out.WriteString(p.colorize(emptyStructures, emptyList))
 				_, _ = p.out.WriteString("\n")
 			} else {
 				_, _ = p.out.WriteString("\n")
@@ -130,7 +145,7 @@ func (p *OutputProcessor) neatYAMLofMapSlice(prefix string, skipIndentOnFirstLin
 func (p *OutputProcessor) neatYAMLofSlice(prefix string, skipIndentOnFirstLine bool, list []interface{}) error {
 	for _, entry := range list {
 		_, _ = p.out.WriteString(prefix)
-		_, _ = p.out.WriteString(p.colorize("-", "dashColor"))
+		_, _ = p.out.WriteString(p.colorize(colorDash, "-"))
 		_, _ = p.out.WriteString(" ")
 		if err := p.neatYAML(prefix+p.prefixAdd(), true, entry); err != nil {
 			return err
@@ -143,7 +158,7 @@ func (p *OutputProcessor) neatYAMLofSlice(prefix string, skipIndentOnFirstLine b
 func (p *OutputProcessor) neatYAMLofScalar(prefix string, skipIndentOnFirstLine bool, obj interface{}) error {
 	// Process nil values immediately and return afterwards
 	if obj == nil {
-		_, _ = p.out.WriteString(p.colorize("null", "nullColor"))
+		_, _ = p.out.WriteString(p.colorize(colorNull, "null"))
 		_, _ = p.out.WriteString("\n")
 		return nil
 	}
@@ -163,7 +178,7 @@ func (p *OutputProcessor) neatYAMLofScalar(prefix string, skipIndentOnFirstLine 
 			_, _ = p.out.WriteString(prefix)
 		}
 
-		_, _ = p.out.WriteString(p.colorize(line, color))
+		_, _ = p.out.WriteString(p.colorize(color, line))
 		_, _ = p.out.WriteString("\n")
 	}
 
@@ -171,14 +186,14 @@ func (p *OutputProcessor) neatYAMLofScalar(prefix string, skipIndentOnFirstLine 
 }
 
 func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bool, node *yamlv3.Node) error {
-	keyStyles := []bunt.StyleOption{}
+	var keyStyles []bunt.StyleOption
 	if p.boldKeys {
 		keyStyles = append(keyStyles, bunt.Bold())
 	}
 
 	switch node.Kind {
 	case yamlv3.DocumentNode:
-		bunt.Fprint(p.out, p.colorize("---", "documentStart"), "\n")
+		bunt.Fprint(p.out, p.colorize(documentStart, "---"), "\n")
 		for _, content := range node.Content {
 			if err := p.neatYAML(prefix, false, content); err != nil {
 				return err
@@ -186,7 +201,7 @@ func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bo
 		}
 
 		if len(node.FootComment) > 0 {
-			fmt.Fprint(p.out, p.colorize(node.FootComment, "commentColor"), "\n")
+			fmt.Fprint(p.out, p.colorize(colorComment, node.FootComment), "\n")
 		}
 
 	case yamlv3.SequenceNode:
@@ -199,7 +214,7 @@ func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bo
 				fmt.Fprint(p.out, prefix)
 			}
 
-			fmt.Fprint(p.out, p.colorize("-", "dashColor"), " ")
+			fmt.Fprint(p.out, p.colorize(colorDash, "-"), " ")
 
 			if err := p.neatYAMLofNode(prefix+p.prefixAdd(), true, entry); err != nil {
 				return err
@@ -214,17 +229,17 @@ func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bo
 
 			key := node.Content[i]
 			if len(key.HeadComment) > 0 {
-				fmt.Fprint(p.out, p.colorize(key.HeadComment, "commentColor"), "\n")
+				fmt.Fprint(p.out, p.colorize(colorComment, key.HeadComment), "\n")
 			}
 			fmt.Fprint(p.out,
-				bunt.Style(p.colorize(fmt.Sprintf("%s:", key.Value), "keyColor"), keyStyles...),
+				bunt.Style(p.colorizef(colorKey, "%s:", key.Value), keyStyles...),
 			)
 
 			value := node.Content[i+1]
 			switch value.Kind {
 			case yamlv3.MappingNode:
 				if len(value.Content) == 0 {
-					fmt.Fprint(p.out, p.createAnchorDefinition(value), " ", p.colorize("{}", "emptyStructures"), "\n")
+					fmt.Fprint(p.out, p.createAnchorDefinition(value), " ", p.colorize(emptyStructures, emptyObject), "\n")
 				} else {
 					fmt.Fprint(p.out, p.createAnchorDefinition(value), "\n")
 					if err := p.neatYAMLofNode(prefix+p.prefixAdd(), false, value); err != nil {
@@ -234,7 +249,7 @@ func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bo
 
 			case yamlv3.SequenceNode:
 				if len(value.Content) == 0 {
-					fmt.Fprint(p.out, p.createAnchorDefinition(value), " ", p.colorize("[]", "emptyStructures"), "\n")
+					fmt.Fprint(p.out, p.createAnchorDefinition(value), " ", p.colorize(emptyStructures, emptyList), "\n")
 				} else {
 					fmt.Fprint(p.out, p.createAnchorDefinition(value), "\n")
 					if err := p.neatYAMLofNode(prefix, false, value); err != nil {
@@ -249,52 +264,52 @@ func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bo
 				}
 
 			case yamlv3.AliasNode:
-				fmt.Fprintf(p.out, " %s\n", p.colorize("*"+value.Value, "anchorColor"))
+				fmt.Fprintf(p.out, " %s\n", p.colorizef(colorAnchor, "*%s", value.Value))
 			}
 
 			if len(key.FootComment) > 0 {
-				fmt.Fprint(p.out, p.colorize(key.FootComment, "commentColor"), "\n")
+				fmt.Fprint(p.out, p.colorize(colorComment, key.FootComment), "\n")
 			}
 		}
 
 	case yamlv3.ScalarNode:
-		var colorName = "scalarDefaultColor"
+		var colorName = colorScalarDefault
 		switch node.Tag {
-		case "!!binary":
-			colorName = "binaryColor"
+		case nodeTagBinary:
+			colorName = colorBinary
 
-		case "!!str":
-			colorName = "scalarDefaultColor"
+		case nodeTagString: // default colorName
+			colorName = colorScalarDefault
 
-		case "!!float":
-			colorName = "floatColor"
+		case nodeTagFloat:
+			colorName = colorFloat
 
-		case "!!int":
-			colorName = "intColor"
+		case nodeTagInt:
+			colorName = colorInt
 
-		case "!!bool":
-			colorName = "boolColor"
+		case nodeTagBool:
+			colorName = colorBool
 
-		case "!!null":
-			colorName = "nullColor"
+		case nodeTagNull:
+			colorName = colorNull
 		}
 
 		lines := strings.Split(node.Value, "\n")
 		switch len(lines) {
 		case 1:
 			if needsQuotes(node) {
-				fmt.Fprint(p.out, p.colorizef(colorName, `"%s"`, node.Value))
+				fmt.Fprint(p.out, p.colorizef(colorName, "%q", node.Value))
 			} else {
-				fmt.Fprint(p.out, p.colorize(node.Value, colorName))
+				fmt.Fprint(p.out, p.colorize(colorName, node.Value))
 			}
 
 		default:
-			colorName = "multiLineTextColor"
-			fmt.Fprint(p.out, p.colorize("|", colorName), "\n")
+			colorName = colorMultiLineText
+			fmt.Fprint(p.out, p.colorize(colorName, "|"), "\n")
 			for i, line := range lines {
 				fmt.Fprint(p.out,
 					prefix,
-					p.colorize(line, colorName),
+					p.colorize(colorName, line),
 				)
 
 				if i != len(lines)-1 {
@@ -304,13 +319,13 @@ func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bo
 		}
 
 		if len(node.LineComment) > 0 {
-			fmt.Fprint(p.out, " ", p.colorize(node.LineComment, "commentColor"))
+			fmt.Fprint(p.out, " ", p.colorize(colorComment, node.LineComment))
 		}
 
 		fmt.Fprint(p.out, "\n")
 
 		if len(node.FootComment) > 0 {
-			fmt.Fprint(p.out, p.colorize(node.FootComment, "commentColor"), "\n")
+			fmt.Fprint(p.out, p.colorize(colorComment, node.FootComment), "\n")
 		}
 
 	case yamlv3.AliasNode:
@@ -343,7 +358,7 @@ func (p *OutputProcessor) neatYAMLOfStruct(prefix string, skipIndentOnFirstLine 
 
 func (p *OutputProcessor) createAnchorDefinition(node *yamlv3.Node) string {
 	if len(node.Anchor) != 0 {
-		return fmt.Sprint(" ", p.colorize("&"+node.Anchor, "anchorColor"))
+		return fmt.Sprint(" ", p.colorizef(colorAnchor, "&%s", node.Anchor))
 	}
 
 	return ""
@@ -351,12 +366,12 @@ func (p *OutputProcessor) createAnchorDefinition(node *yamlv3.Node) string {
 
 func needsQuotes(node *yamlv3.Node) bool {
 	// skip all non string nodes
-	if node.Tag != "!!str" {
+	if node.Tag != nodeTagString {
 		return false
 	}
 
 	// check if string matches one of the known reserved keywords
-	for _, chk := range []string{"true", "false", "null"} {
+	for _, chk := range yamlReservedKeywords {
 		if node.Value == chk {
 			return true
 		}


### PR DESCRIPTION
Introduce constants for color names.

Simplify setup of `colorize` and `colorizef`.
