### PR TITLE
Fix wrong length check

### DIFF
--- a/output_yaml.go
+++ b/output_yaml.go
@@ -194,7 +194,7 @@ func (p *OutputProcessor) neatYAMLofNode(prefix string, skipIndentOnFirstLine bo
 
 	switch node.Kind {
 	case yamlv3.DocumentNode:
-		if len(node.Content) != 1 && p.enforceDocumentStartMarker {
+		if p.enforceDocumentStartMarker {
 			_, _ = bunt.Fprint(p.out, p.colorize(documentStart, "---"), "\n")
 		}
 

--- a/output_yaml_test.go
+++ b/output_yaml_test.go
@@ -398,6 +398,20 @@ data:
 			Expect(err).ToNot(HaveOccurred())
 			Expect(output).To(BeEquivalentTo(expected))
 		})
+
+		It("should omit the document start marker by default", func() {
+			example := []byte(`foo: bar`)
+
+			expected := `foo: bar
+`
+
+			var node yamlv3.Node
+			Expect(yamlv3.Unmarshal(example, &node)).ToNot(HaveOccurred())
+
+			output, err := toYAMLString(node)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output).To(BeEquivalentTo(expected))
+		})
 	})
 
 	Context("create YAML output for type struct", func() {


### PR DESCRIPTION
The document node will only have one entry in content. Multi document YAMLs have multiple document nodes.
